### PR TITLE
Again build Fedora37

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
   build:
     strategy:
       matrix:
-        image: ["debug", "fedora38", "fedora37-test", "alma8", "ubuntu2210", "ubuntu22", "ubuntu20", "ubuntu18"]
+        image: ["debug", "fedora37", "fedora37-test", "fedora38", "alma8", "ubuntu2210", "ubuntu22", "ubuntu20", "ubuntu18"]
       fail-fast: false
 
     runs-on: ubuntu-latest


### PR DESCRIPTION
Commit 7b04ba5163 *replaced* fedora37 by fedora38, but we actually use both for testing and we need a new version with an updated nbconvert.