### PR TITLE
Do not install Python distro packages that are also installed through…

### DIFF
--- a/alma8/Dockerfile
+++ b/alma8/Dockerfile
@@ -1,21 +1,18 @@
 FROM gitlab-registry.cern.ch/linuxsupport/alma8-base
 
 COPY packages.txt packages.txt
-
-RUN dnf update -q -y \
- && dnf install -y epel-release \
- && dnf install -y --setopt=install_weak_deps=False $(cat packages.txt) \
- && dnf autoremove \
- && dnf clean all \
- && rm -f packages.txt \
- && curl -O -L https://github.com/Kitware/CMake/releases/download/v3.26.2/cmake-3.26.2-linux-x86_64.sh \
- && sh ./cmake-*.sh --skip-license --prefix=/usr/local/ \
- && rm ./cmake-*.sh
-
-
 ADD https://raw.githubusercontent.com/root-project/root/master/requirements.txt requirements-root.txt
 ADD https://raw.githubusercontent.com/root-project/roottest/master/requirements.txt requirements-roottest.txt
 
-RUN python3 -m pip install --upgrade pip \
- && python3 -m pip install -r requirements-root.txt -r requirements-roottest.txt 'openstacksdk<=1.2.0' \
+RUN dnf update -y \
+ && dnf install -y epel-release \
+ && dnf install -y --setopt=install_weak_deps=False $(cat packages.txt) \
+ && rm -f packages.txt \
+ && dnf clean all \
+ && rm -rf /var/cache/dnf
+
+RUN mkdir -p /py-venv \
+ && python3 -m venv /py-venv/ROOT-CI \
+ && /py-venv/ROOT-CI/bin/pip install --upgrade pip \
+ && /py-venv/ROOT-CI/bin/pip install -r requirements-root.txt -r requirements-roottest.txt openstacksdk \
  && rm -f requirements-root.txt requirements-roottest.txt

--- a/alma8/packages.txt
+++ b/alma8/packages.txt
@@ -52,9 +52,6 @@ protobuf-devel
 pythia8-devel
 python3
 python3-devel
-python3-numpy
-python3-pip
-python3-virtualenv
 qt5-qtwebengine-devel
 R-devel
 R-Rcpp-devel

--- a/alma9/Dockerfile
+++ b/alma9/Dockerfile
@@ -1,21 +1,18 @@
 FROM gitlab-registry.cern.ch/linuxsupport/alma9-base
 
 COPY packages.txt packages.txt
-
-RUN dnf update -q -y \
- && dnf install -y epel-release \
- && dnf install -y --setopt=install_weak_deps=False $(cat packages.txt) \
- && dnf autoremove \
- && dnf clean all \
- && rm -f packages.txt \
- && curl -O -L https://github.com/Kitware/CMake/releases/download/v3.26.2/cmake-3.26.2-linux-x86_64.sh \
- && sh ./cmake-*.sh --skip-license --prefix=/usr/local/ \
- && rm ./cmake-*.sh
-
-
 ADD https://raw.githubusercontent.com/root-project/root/master/requirements.txt requirements-root.txt
 ADD https://raw.githubusercontent.com/root-project/roottest/master/requirements.txt requirements-roottest.txt
 
-RUN python3 -m pip install --upgrade pip \
- && python3 -m pip install -r requirements-root.txt -r requirements-roottest.txt 'openstacksdk<=1.2.0' \
+RUN dnf update -y \
+ && dnf install -y epel-release \
+ && dnf install -y --setopt=install_weak_deps=False $(cat packages.txt) \
+ && rm -f packages.txt \
+ && dnf clean all \
+ && rm -rf /var/cache/dnf
+
+RUN mkdir -p /py-venv \
+ && python3 -m venv /py-venv/ROOT-CI \
+ && /py-venv/ROOT-CI/bin/pip install --upgrade pip \
+ && /py-venv/ROOT-CI/bin/pip install -r requirements-root.txt -r requirements-roottest.txt openstacksdk \
  && rm -f requirements-root.txt requirements-roottest.txt

--- a/alma9/packages.txt
+++ b/alma9/packages.txt
@@ -53,9 +53,6 @@ protobuf-devel
 pythia8-devel
 python3
 python3-devel
-python3-numpy
-python3-pip
-python3-virtualenv
 qt5-qtwebengine-devel
 R-devel
 R-Rcpp-devel

--- a/fedora37-test/Dockerfile
+++ b/fedora37-test/Dockerfile
@@ -1,22 +1,17 @@
-
 FROM fedora:37
 
-# RUN useradd -s /bin/bash sftnight
+COPY packages.txt packages.txt
+ADD https://raw.githubusercontent.com/root-project/root/master/requirements.txt requirements-root.txt
+ADD https://raw.githubusercontent.com/root-project/roottest/master/requirements.txt requirements-roottest.txt
 
 RUN dnf update -y \
- && dnf clean all \
- && rm -rf /var/cache/dnf
-
-COPY packages.txt packages.txt
-
-RUN dnf install $(cat packages.txt) -y --setopt=install_weak_deps=False \
+ && dnf install $(cat packages.txt) -y --setopt=install_weak_deps=False \
  && rm -f packages.txt \
  && dnf clean all \
  && rm -rf /var/cache/dnf
 
-ADD https://raw.githubusercontent.com/root-project/root/master/requirements.txt requirements-root.txt
-ADD https://raw.githubusercontent.com/root-project/roottest/master/requirements.txt requirements-roottest.txt
-
-RUN python3 -m pip install --upgrade pip \
- && python3 -m pip install -r requirements-root.txt -r requirements-roottest.txt openstacksdk \
+RUN mkdir -p /py-venv \
+ && python3 -m venv /py-venv/ROOT-CI \
+ && /py-venv/ROOT-CI/bin/pip install --upgrade pip \
+ && /py-venv/ROOT-CI/bin/pip install -r requirements-root.txt -r requirements-roottest.txt openstacksdk \
  && rm -f requirements-root.txt requirements-roottest.txt

--- a/fedora37-test/packages.txt
+++ b/fedora37-test/packages.txt
@@ -1,4 +1,3 @@
-
 avahi-compat-libdns_sd-devel
 avahi-devel
 binutils
@@ -47,9 +46,6 @@ protobuf-devel
 pythia8-devel
 python3
 python3-devel
-python3-numpy
-python3-pip
-python3-virtualenv
 qt5-qtwebengine-devel
 R-devel
 R-Rcpp-devel

--- a/fedora37/Dockerfile
+++ b/fedora37/Dockerfile
@@ -1,22 +1,17 @@
-
 FROM fedora:37
 
-# RUN useradd -s /bin/bash sftnight
+COPY packages.txt packages.txt
+ADD https://raw.githubusercontent.com/root-project/root/master/requirements.txt requirements-root.txt
+ADD https://raw.githubusercontent.com/root-project/roottest/master/requirements.txt requirements-roottest.txt
 
 RUN dnf update -y \
- && dnf clean all \
- && rm -rf /var/cache/dnf
-
-COPY packages.txt packages.txt
-
-RUN dnf install $(cat packages.txt) -y --setopt=install_weak_deps=False \
+ && dnf install -y --setopt=install_weak_deps=False $(cat packages.txt) \
  && rm -f packages.txt \
  && dnf clean all \
  && rm -rf /var/cache/dnf
 
-ADD https://raw.githubusercontent.com/root-project/root/master/requirements.txt requirements-root.txt
-ADD https://raw.githubusercontent.com/root-project/roottest/master/requirements.txt requirements-roottest.txt
-
-RUN python3 -m pip install --upgrade pip \
- && python3 -m pip install -r requirements-root.txt -r requirements-roottest.txt openstacksdk \
+RUN mkdir -p /py-venv \
+ && python3 -m venv /py-venv/ROOT-CI \
+ && /py-venv/ROOT-CI/bin/pip install --upgrade pip \
+ && /py-venv/ROOT-CI/bin/pip install -r requirements-root.txt -r requirements-roottest.txt openstacksdk \
  && rm -f requirements-root.txt requirements-roottest.txt

--- a/fedora37/packages.txt
+++ b/fedora37/packages.txt
@@ -50,11 +50,6 @@ protobuf-devel
 pythia8-devel
 python3
 python3-devel
-python3-devel
-python3-numpy
-python3-numpy
-python3-pip
-python3-virtualenv
 qt5-qtwebengine-devel
 R-devel
 R-Rcpp-devel

--- a/fedora38/Dockerfile
+++ b/fedora38/Dockerfile
@@ -1,21 +1,17 @@
 FROM fedora:38
 
-# RUN useradd -s /bin/bash sftnight
+COPY packages.txt packages.txt
+ADD https://raw.githubusercontent.com/root-project/root/master/requirements.txt requirements-root.txt
+ADD https://raw.githubusercontent.com/root-project/roottest/master/requirements.txt requirements-roottest.txt
 
 RUN dnf update -y \
- && dnf clean all \
- && rm -rf /var/cache/dnf
-
-COPY packages.txt packages.txt
-
-RUN dnf install $(cat packages.txt) -y --setopt=install_weak_deps=False \
+ && dnf install -y --setopt=install_weak_deps=False $(cat packages.txt) \
  && rm -f packages.txt \
  && dnf clean all \
  && rm -rf /var/cache/dnf
 
-ADD https://raw.githubusercontent.com/root-project/root/master/requirements.txt requirements-root.txt
-ADD https://raw.githubusercontent.com/root-project/roottest/master/requirements.txt requirements-roottest.txt
-
-RUN python3 -m pip install --upgrade pip \
- && python3 -m pip install -r requirements-root.txt -r requirements-roottest.txt openstacksdk \
+RUN mkdir -p /py-venv \
+ && python3 -m venv /py-venv/ROOT-CI \
+ && /py-venv/ROOT-CI/bin/pip install --upgrade pip \
+ && /py-venv/ROOT-CI/bin/pip install -r requirements-root.txt -r requirements-roottest.txt openstacksdk \
  && rm -f requirements-root.txt requirements-roottest.txt

--- a/fedora38/packages.txt
+++ b/fedora38/packages.txt
@@ -50,11 +50,6 @@ protobuf-devel
 pythia8-devel
 python3
 python3-devel
-python3-devel
-python3-numpy
-python3-numpy
-python3-pip
-python3-virtualenv
 qt5-qtwebengine-devel
 R-devel
 R-Rcpp-devel

--- a/fedora39/Dockerfile
+++ b/fedora39/Dockerfile
@@ -1,22 +1,18 @@
 FROM fedora:39
 
-# RUN useradd -s /bin/bash sftnight
+COPY packages.txt packages.txt
+ADD https://raw.githubusercontent.com/root-project/root/master/requirements.txt requirements-root.txt
+ADD https://raw.githubusercontent.com/root-project/roottest/master/requirements.txt requirements-roottest.txt
 
 RUN dnf update -y \
- && dnf clean all \
- && rm -rf /var/cache/dnf
-
-COPY packages.txt packages.txt
-
-RUN dnf install $(cat packages.txt) -y --setopt=install_weak_deps=False \
+ && dnf install -y --setopt=install_weak_deps=False $(cat packages.txt) \
  && rm -f packages.txt \
  && dnf clean all \
  && rm -rf /var/cache/dnf
 
-ADD https://raw.githubusercontent.com/root-project/root/master/requirements.txt requirements-root.txt
-ADD https://raw.githubusercontent.com/root-project/roottest/master/requirements.txt requirements-roottest.txt
-
-RUN mkdir -p /py-venv && python3 -m venv /py-venv/ROOT-CI && /py-venv/ROOT-CI/bin/pip install --upgrade pip \
+RUN mkdir -p /py-venv \
+ && python3 -m venv /py-venv/ROOT-CI \
+ && /py-venv/ROOT-CI/bin/pip install --upgrade pip \
  && /py-venv/ROOT-CI/bin/pip install -r requirements-root.txt -r requirements-roottest.txt openstacksdk \
  && rm -f requirements-root.txt requirements-roottest.txt
 

--- a/fedora39/packages.txt
+++ b/fedora39/packages.txt
@@ -50,11 +50,6 @@ protobuf-devel
 pythia8-devel
 python3
 python3-devel
-python3-devel
-python3-numpy
-python3-numpy
-python3-pip
-python3-virtualenv
 qt5-qtwebengine-devel
 R-devel
 R-Rcpp-devel

--- a/ubuntu20/Dockerfile
+++ b/ubuntu20/Dockerfile
@@ -1,11 +1,10 @@
 FROM ubuntu:20.04
 
-# RUN useradd -s /bin/bash sftnight
-
 ENV LANG=C.UTF-8
 
-
 COPY packages.txt packages.txt
+ADD https://raw.githubusercontent.com/root-project/root/master/requirements.txt requirements-root.txt
+ADD https://raw.githubusercontent.com/root-project/roottest/master/requirements.txt requirements-roottest.txt
 
 RUN apt-get update -qq \
  && ln -sf /usr/share/zoneinfo/UTC /etc/localtime  \
@@ -14,25 +13,12 @@ RUN apt-get update -qq \
  && apt-get clean -y \
  && rm -rf /var/cache/apt/archives/* \
  && rm -rf /var/lib/apt/lists/* \
- && rm packages.txt \
- && update-ca-certificates \
- && curl -O -L https://github.com/Kitware/CMake/releases/download/v3.26.2/cmake-3.26.2-linux-x86_64.sh \
- && sh ./cmake-*.sh --skip-license --prefix=/usr/local/ \
- && rm ./cmake-*.sh
+ && rm packages.txt
 
+RUN update-ca-certificates
 
-ADD https://raw.githubusercontent.com/root-project/root/master/requirements.txt requirements-root.txt
-ADD https://raw.githubusercontent.com/root-project/roottest/master/requirements.txt requirements-roottest.txt
-
-RUN python3 -m pip install --upgrade pip \
- && python3 -m pip install -r requirements-root.txt -r requirements-roottest.txt openstacksdk \
+RUN mkdir -p /py-venv \
+ && python3 -m venv /py-venv/ROOT-CI \
+ && /py-venv/ROOT-CI/bin/pip install --upgrade pip \
+ && /py-venv/ROOT-CI/bin/pip install -r requirements-root.txt -r requirements-roottest.txt openstacksdk \
  && rm -f requirements-root.txt requirements-roottest.txt
-
-
-
-#RUN yes | unminimize \
-# && apt-get autoremove -y \
-# && apt-get clean -y \
-# && rm -rf /var/cache/apt/archives/* \
-# && rm -rf /var/lib/apt/lists/*
-

--- a/ubuntu20/packages.txt
+++ b/ubuntu20/packages.txt
@@ -66,10 +66,6 @@ ninja-build
 protobuf-compiler
 python3
 python3-dev
-python3-numpy
-python3-pip
-python3-pytest
-python3-setuptools
 python3-venv
 qtwebengine5-dev
 r-base

--- a/ubuntu22/Dockerfile
+++ b/ubuntu22/Dockerfile
@@ -1,13 +1,10 @@
-
 FROM ubuntu:22.04
-
-# RUN useradd -s /bin/bash sftnight
 
 ENV LANG=C.UTF-8
 
-
-
 COPY packages.txt packages.txt
+ADD https://raw.githubusercontent.com/root-project/root/master/requirements.txt requirements-root.txt
+ADD https://raw.githubusercontent.com/root-project/roottest/master/requirements.txt requirements-roottest.txt
 
 RUN apt-get update -qq \
  && ln -sf /usr/share/zoneinfo/UTC /etc/localtime  \
@@ -18,21 +15,10 @@ RUN apt-get update -qq \
  && rm -rf /var/lib/apt/lists/* \
  && rm packages.txt
 
-
-
-ADD https://raw.githubusercontent.com/root-project/root/master/requirements.txt requirements-root.txt
-ADD https://raw.githubusercontent.com/root-project/roottest/master/requirements.txt requirements-roottest.txt
-
-RUN python3 -m pip install --upgrade pip \
- && python3 -m pip install -r requirements-root.txt -r requirements-roottest.txt openstacksdk \
- && rm -f requirements-root.txt requirements-roottest.txt
-
-
 RUN update-ca-certificates
 
-#RUN yes | unminimize \
-# && apt-get autoremove -y \
-# && apt-get clean -y \
-# && rm -rf /var/cache/apt/archives/* \
-# && rm -rf /var/lib/apt/lists/*
-
+RUN mkdir -p /py-venv \
+ && python3 -m venv /py-venv/ROOT-CI \
+ && /py-venv/ROOT-CI/bin/pip install --upgrade pip \
+ && /py-venv/ROOT-CI/bin/pip install -r requirements-root.txt -r requirements-roottest.txt openstacksdk \
+ && rm -f requirements-root.txt requirements-roottest.txt

--- a/ubuntu22/packages.txt
+++ b/ubuntu22/packages.txt
@@ -67,10 +67,6 @@ ninja-build
 nlohmann-json3-dev
 python3
 python3-dev
-python3-numpy
-python3-pip
-python3-pytest
-python3-setuptools
 python3-venv
 qtwebengine5-dev
 r-base

--- a/ubuntu2304/Dockerfile
+++ b/ubuntu2304/Dockerfile
@@ -1,13 +1,10 @@
-
 FROM ubuntu:23.04
-
-# RUN useradd -s /bin/bash sftnight
 
 ENV LANG=C.UTF-8
 
-
-
 COPY packages.txt packages.txt
+ADD https://raw.githubusercontent.com/root-project/root/master/requirements.txt requirements-root.txt
+ADD https://raw.githubusercontent.com/root-project/roottest/master/requirements.txt requirements-roottest.txt
 
 RUN apt-get update -qq \
  && ln -sf /usr/share/zoneinfo/UTC /etc/localtime  \
@@ -18,20 +15,10 @@ RUN apt-get update -qq \
  && rm -rf /var/lib/apt/lists/* \
  && rm packages.txt
 
-
-
-ADD https://raw.githubusercontent.com/root-project/root/master/requirements.txt requirements-root.txt
-ADD https://raw.githubusercontent.com/root-project/roottest/master/requirements.txt requirements-roottest.txt
-
-RUN mkdir -p /py-venv && python3 -m venv /py-venv/ROOT-CI && /py-venv/ROOT-CI/bin/pip install --upgrade pip \
- && /py-venv/ROOT-CI/bin/pip install -r requirements-root.txt -r requirements-roottest.txt openstacksdk \
- && rm -f requirements-root.txt requirements-roottest.txt
-
 RUN update-ca-certificates
 
-#RUN yes | unminimize \
-# && apt-get autoremove -y \
-# && apt-get clean -y \
-# && rm -rf /var/cache/apt/archives/* \
-# && rm -rf /var/lib/apt/lists/*
-
+RUN mkdir -p /py-venv \
+ && python3 -m venv /py-venv/ROOT-CI \
+ && /py-venv/ROOT-CI/bin/pip install --upgrade pip \
+ && /py-venv/ROOT-CI/bin/pip install -r requirements-root.txt -r requirements-roottest.txt openstacksdk \
+ && rm -f requirements-root.txt requirements-roottest.txt

--- a/ubuntu2304/packages.txt
+++ b/ubuntu2304/packages.txt
@@ -67,10 +67,6 @@ ninja-build
 nlohmann-json3-dev
 python3
 python3-dev
-python3-numpy
-python3-pip
-python3-pytest
-python3-setuptools
 python3-venv
 qtwebengine5-dev
 r-base

--- a/ubuntu2310/Dockerfile
+++ b/ubuntu2310/Dockerfile
@@ -1,10 +1,10 @@
 FROM ubuntu:23.10
 
-# RUN useradd -s /bin/bash sftnight
-
 ENV LANG=C.UTF-8
 
 COPY packages.txt packages.txt
+ADD https://raw.githubusercontent.com/root-project/root/master/requirements.txt requirements-root.txt
+ADD https://raw.githubusercontent.com/root-project/roottest/master/requirements.txt requirements-roottest.txt
 
 RUN apt-get update -qq \
  && ln -sf /usr/share/zoneinfo/UTC /etc/localtime  \
@@ -15,20 +15,10 @@ RUN apt-get update -qq \
  && rm -rf /var/lib/apt/lists/* \
  && rm packages.txt
 
-
-
-ADD https://raw.githubusercontent.com/root-project/root/master/requirements.txt requirements-root.txt
-ADD https://raw.githubusercontent.com/root-project/roottest/master/requirements.txt requirements-roottest.txt
-
-RUN mkdir -p /py-venv && python3 -m venv /py-venv/ROOT-CI && /py-venv/ROOT-CI/bin/pip install --upgrade pip \
- && /py-venv/ROOT-CI/bin/pip install -r requirements-root.txt -r requirements-roottest.txt openstacksdk \
- && rm -f requirements-root.txt requirements-roottest.txt
-
 RUN update-ca-certificates
 
-#RUN yes | unminimize \
-# && apt-get autoremove -y \
-# && apt-get clean -y \
-# && rm -rf /var/cache/apt/archives/* \
-# && rm -rf /var/lib/apt/lists/*
-
+RUN mkdir -p /py-venv \
+ && python3 -m venv /py-venv/ROOT-CI \
+ && /py-venv/ROOT-CI/bin/pip install --upgrade pip \
+ && /py-venv/ROOT-CI/bin/pip install -r requirements-root.txt -r requirements-roottest.txt openstacksdk \
+ && rm -f requirements-root.txt requirements-roottest.txt

--- a/ubuntu2310/packages.txt
+++ b/ubuntu2310/packages.txt
@@ -67,10 +67,6 @@ ninja-build
 nlohmann-json3-dev
 python3
 python3-dev
-python3-numpy
-python3-pip
-python3-pytest
-python3-setuptools
 python3-venv
 qtwebengine5-dev
 r-base


### PR DESCRIPTION
… requirements.txt:

Also
- virtualenv is not venv and not needed;
- split RUN lines
- move ADD lines early: these files rarely change
- remove commented lines
- use venv throughout all (current) distros.