### PR TITLE
Install openstacksdk version compatible with Alma8's Python 3.6

### DIFF
--- a/alma8/Dockerfile
+++ b/alma8/Dockerfile
@@ -14,5 +14,5 @@ RUN dnf update -y \
 RUN mkdir -p /py-venv \
  && python3 -m venv /py-venv/ROOT-CI \
  && /py-venv/ROOT-CI/bin/pip install --upgrade pip \
- && /py-venv/ROOT-CI/bin/pip install -r requirements-root.txt -r requirements-roottest.txt openstacksdk \
+ && /py-venv/ROOT-CI/bin/pip install -r requirements-root.txt -r requirements-roottest.txt openstacksdk==1.4.0 \
  && rm -f requirements-root.txt requirements-roottest.txt


### PR DESCRIPTION
The openstacksdk Python package uses certain features only available in Python 3.8 since version 1.5.0 without advertising this to pip. See bug report at https://storyboard.openstack.org/#!/story/2010903.


Note: I hope this version of the package will also have all the things necessary for our CI, I'm not sure