### PR TITLE
Enable CodeReady Builder repo for Alma9:

### DIFF
--- a/alma9/Dockerfile
+++ b/alma9/Dockerfile
@@ -6,6 +6,8 @@ ADD https://raw.githubusercontent.com/root-project/roottest/master/requirements.
 
 RUN dnf update -y \
  && dnf install -y epel-release \
+ && dnf install -y 'dnf-command(config-manager)' \
+ && crb enable \
  && dnf install -y --setopt=install_weak_deps=False $(cat packages.txt) \
  && rm -f packages.txt \
  && dnf clean all \

--- a/alma9/packages.txt
+++ b/alma9/packages.txt
@@ -53,7 +53,7 @@ protobuf-devel
 pythia8-devel
 python3
 python3-devel
-qt5-qtwebengine-devel
+qt6-qtwebengine-devel
 R-devel
 R-Rcpp-devel
 R-RInside-devel


### PR DESCRIPTION
Hopefully this fixes the issue with Qt5 package dependencies.