### PR TITLE
Enforce Python 3.8 in Alma8 image

### DIFF
--- a/alma8/packages.txt
+++ b/alma8/packages.txt
@@ -51,8 +51,8 @@ postgresql-devel
 protobuf-compiler
 protobuf-devel
 pythia8-devel
-python3
-python3-devel
+python38
+python38-devel
 qt5-qtwebengine-devel
 R-devel
 R-Rcpp-devel


### PR DESCRIPTION
In preparation of the removal of Python 2 support. The minimum Python version required will be set to 3.8, since it is the minimum version which is not EOL at the moment. On Centos8 and derivatives, the default Python 3 version is 3.6, but the official channels also provide more recent versions of Python.