### PR TITLE
Use `--system-site-packages` on alma9 and fedora39+

### DIFF
--- a/alma9/Dockerfile
+++ b/alma9/Dockerfile
@@ -13,8 +13,11 @@ RUN dnf update -y \
  && dnf clean all \
  && rm -rf /var/cache/dnf
 
+# We consider the system packages in the python environment to make sure we pick
+# up a version of NumPy that is compiled with a system-compatible blas
+# implementation.
 RUN mkdir -p /py-venv \
- && python3 -m venv /py-venv/ROOT-CI \
+ && python3 -m venv --system-site-packages /py-venv/ROOT-CI \
  && /py-venv/ROOT-CI/bin/pip install --no-cache-dir --upgrade pip \
  && /py-venv/ROOT-CI/bin/pip install --no-cache-dir -r requirements-root.txt -r requirements-roottest.txt openstacksdk \
  && rm -f requirements-root.txt requirements-roottest.txt

--- a/fedora39/Dockerfile
+++ b/fedora39/Dockerfile
@@ -10,8 +10,11 @@ RUN dnf update -y \
  && dnf clean all \
  && rm -rf /var/cache/dnf
 
+# We consider the system packages in the python environment to make sure we pick
+# up a version of NumPy that is compiled with a system-compatible blas
+# implementation.
 RUN mkdir -p /py-venv \
- && python3 -m venv /py-venv/ROOT-CI \
+ && python3 -m venv --system-site-packages /py-venv/ROOT-CI \
  && /py-venv/ROOT-CI/bin/pip install --no-cache-dir --upgrade pip \
  && /py-venv/ROOT-CI/bin/pip install --no-cache-dir -r requirements-root.txt -r requirements-roottest.txt openstacksdk \
  && rm -f requirements-root.txt requirements-roottest.txt

--- a/fedora40/Dockerfile
+++ b/fedora40/Dockerfile
@@ -10,8 +10,11 @@ RUN dnf update -y \
  && dnf clean all \
  && rm -rf /var/cache/dnf
 
+# We consider the system packages in the python environment to make sure we pick
+# up a version of NumPy that is compiled with a system-compatible blas
+# implementation.
 RUN mkdir -p /py-venv \
- && python3 -m venv /py-venv/ROOT-CI \
+ && python3 -m venv --system-site-packages /py-venv/ROOT-CI \
  && /py-venv/ROOT-CI/bin/pip install --no-cache-dir --upgrade pip \
  && /py-venv/ROOT-CI/bin/pip install --no-cache-dir -r requirements-root.txt -r requirements-roottest.txt openstacksdk \
  && rm -f requirements-root.txt requirements-roottest.txt


### PR DESCRIPTION
We consider the system packages in the python environment to make sure we pick up a version of NumPy that is compiled with a system-compatible blas implementation.