### PR TITLE
Move nightly build to 0:10 UTC

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
       - main
   schedule:
     # every day
-    - cron:  '0 2 * * *'
+    - cron:  '10 0 * * *'
 
 jobs:
   build:


### PR DESCRIPTION
This will allow ROOT nightly builds to run afterwards with the new images.