### PR TITLE
Don't attempt to use system NumPy package on alma9 and fedora39+

### DIFF
--- a/alma9/Dockerfile
+++ b/alma9/Dockerfile
@@ -13,11 +13,8 @@ RUN dnf update -y \
  && dnf clean all \
  && rm -rf /var/cache/dnf
 
-# We consider the system packages in the python environment to make sure we pick
-# up a version of NumPy that is compiled with a system-compatible blas
-# implementation.
 RUN mkdir -p /py-venv \
- && python3 -m venv --system-site-packages /py-venv/ROOT-CI \
+ && python3 -m venv /py-venv/ROOT-CI \
  && /py-venv/ROOT-CI/bin/pip install --no-cache-dir --upgrade pip \
  && /py-venv/ROOT-CI/bin/pip install --no-cache-dir -r requirements-root.txt -r requirements-roottest.txt openstacksdk \
  && rm -f requirements-root.txt requirements-roottest.txt

--- a/alma9/packages.txt
+++ b/alma9/packages.txt
@@ -55,7 +55,6 @@ protobuf-devel
 pythia8-devel
 python3
 python3-devel
-python3-numpy
 qt6-qtwebengine-devel
 R-devel
 R-Rcpp-devel

--- a/fedora39/Dockerfile
+++ b/fedora39/Dockerfile
@@ -10,11 +10,8 @@ RUN dnf update -y \
  && dnf clean all \
  && rm -rf /var/cache/dnf
 
-# We consider the system packages in the python environment to make sure we pick
-# up a version of NumPy that is compiled with a system-compatible blas
-# implementation.
 RUN mkdir -p /py-venv \
- && python3 -m venv --system-site-packages /py-venv/ROOT-CI \
+ && python3 -m venv /py-venv/ROOT-CI \
  && /py-venv/ROOT-CI/bin/pip install --no-cache-dir --upgrade pip \
  && /py-venv/ROOT-CI/bin/pip install --no-cache-dir -r requirements-root.txt -r requirements-roottest.txt openstacksdk \
  && rm -f requirements-root.txt requirements-roottest.txt

--- a/fedora39/packages.txt
+++ b/fedora39/packages.txt
@@ -51,7 +51,6 @@ protobuf-devel
 pythia8-devel
 python3
 python3-devel
-python3-numpy
 qt5-qtwebengine-devel
 R-devel
 R-Rcpp-devel

--- a/fedora40/Dockerfile
+++ b/fedora40/Dockerfile
@@ -10,11 +10,8 @@ RUN dnf update -y \
  && dnf clean all \
  && rm -rf /var/cache/dnf
 
-# We consider the system packages in the python environment to make sure we pick
-# up a version of NumPy that is compiled with a system-compatible blas
-# implementation.
 RUN mkdir -p /py-venv \
- && python3 -m venv --system-site-packages /py-venv/ROOT-CI \
+ && python3 -m venv /py-venv/ROOT-CI \
  && /py-venv/ROOT-CI/bin/pip install --no-cache-dir --upgrade pip \
  && /py-venv/ROOT-CI/bin/pip install --no-cache-dir -r requirements-root.txt -r requirements-roottest.txt openstacksdk \
  && rm -f requirements-root.txt requirements-roottest.txt

--- a/fedora40/packages.txt
+++ b/fedora40/packages.txt
@@ -51,7 +51,6 @@ protobuf-devel
 pythia8-devel
 python3
 python3-devel
-python3-numpy
 qt5-qtwebengine-devel
 R-devel
 R-Rcpp-devel


### PR DESCRIPTION
This reverts commit d5541226e0 and parts of 797303ac9e2c.

Using the system NumPy package didn't work after all, because the requirements resolved to a different numpy version constraint than the one on the system.