### PR TITLE
Add `python3-numpy` to alma9 image

### DIFF
--- a/alma9/packages.txt
+++ b/alma9/packages.txt
@@ -55,6 +55,7 @@ protobuf-devel
 pythia8-devel
 python3
 python3-devel
+python3-numpy
 qt6-qtwebengine-devel
 R-devel
 R-Rcpp-devel


### PR DESCRIPTION
This might fix the build failure of the `alma9` images:
```
#12 64.87 Error: 
#12 64.87  Problem: package qt6-qtwebengine-devel-6.6.2-1.el9.x86_64 from epel requires pkgconfig(Qt6Core), but none of the providers can be installed
#12 64.87   - package qt6-qtwebengine-devel-6.6.2-1.el9.x86_64 from epel requires qt6-qtbase-devel(x86-64), but none of the providers can be installed
#12 64.87   - package qt6-qtwebengine-devel-6.6.2-1.el9.x86_64 from epel requires pkgconfig(Qt6Gui), but none of the providers can be installed
#12 64.87   - package qt6-qtwebengine-devel-6.6.2-1.el9.x86_64 from epel requires pkgconfig(Qt6Network), but none of the providers can be installed
#12 64.87   - package qt6-qtwebengine-devel-6.6.2-1.el9.x86_64 from epel requires pkgconfig(Qt6Widgets), but none of the providers can be installed
#12 64.87   - package qt6-qtwebengine-devel-6.6.2-1.el9.x86_64 from epel requires pkgconfig(Qt6PrintSupport), but none of the providers can be installed
#12 64.87   - package qt6-qtbase-devel-6.6.2-1.el9.x86_64 from epel requires libQt6Gui.so.6()(64bit), but none of the providers can be installed
#12 64.87   - package qt6-qtbase-devel-6.6.2-1.el9.x86_64 from epel requires libQt6Widgets.so.6()(64bit), but none of the providers can be installed
#12 64.87   - package qt6-qtbase-devel-6.6.2-1.el9.x86_64 from epel requires libQt6OpenGL.so.6()(64bit), but none of the providers can be installed
#12 64.87   - package qt6-qtbase-devel-6.6.2-1.el9.x86_64 from epel requires libQt6PrintSupport.so.6()(64bit), but none of the providers can be installed
#12 64.87   - package qt6-qtbase-devel-6.6.2-1.el9.x86_64 from epel requires libQt6OpenGLWidgets.so.6()(64bit), but none of the providers can be installed
#12 64.87   - package qt6-qtbase-devel-6.6.2-1.el9.x86_64 from epel requires libQt6EglFSDeviceIntegration.so.6()(64bit), but none of the providers can be installed
#12 64.87   - package qt6-qtbase-devel-6.6.2-1.el9.x86_64 from epel requires libQt6EglFsKmsGbmSupport.so.6()(64bit), but none of the providers can be installed
#12 64.87   - package qt6-qtbase-devel-6.6.2-1.el9.x86_64 from epel requires libQt6EglFsKmsSupport.so.6()(64bit), but none of the providers can be installed
#12 64.87   - package qt6-qtbase-devel-6.6.2-1.el9.x86_64 from epel requires libQt6XcbQpa.so.6()(64bit), but none of the providers can be installed
#12 64.87   - package qt6-qtbase-devel-6.6.2-1.el9.x86_64 from epel requires qt6-qtbase-gui(x86-64), but none of the providers can be installed
#12 64.87   - conflicting requests
#12 64.87   - nothing provides libxcb-cursor.so.0()(64bit) needed by qt6-qtbase-gui-6.6.2-1.el9.x86_64 from epel
#12 64.87 (try to add '--skip-broken' to skip uninstallable packages or '--nobest' to use not only best candidate packages)
```