### PR TITLE
Free disk space to prevent IO errors on push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet || true
+          sudo rm -rf /usr/local/lib/android || true
+
       - name: Checkout
         uses: actions/checkout@v4
 


### PR DESCRIPTION
Although the CI ran successfully, the push step in the nightlies failed, because it was out of space. Here, we retry after purging android and dotnet.