### PR TITLE
Add ccache to all containers.

### DIFF
--- a/alma8/packages.txt
+++ b/alma8/packages.txt
@@ -71,3 +71,4 @@ xxhash-devel
 xz-devel
 zeromq-devel
 zlib-devel
+ccache

--- a/alma9-clang/packages.txt
+++ b/alma9-clang/packages.txt
@@ -72,3 +72,4 @@ xxhash-devel
 xz-devel
 zeromq-devel
 zlib-devel
+ccache

--- a/alma9/packages.txt
+++ b/alma9/packages.txt
@@ -75,3 +75,4 @@ xxhash-devel
 xz-devel
 zeromq-devel
 zlib-devel
+ccache

--- a/debian125/packages.txt
+++ b/debian125/packages.txt
@@ -78,3 +78,4 @@ uuid-dev
 wget
 xlibmesa-glu-dev
 xrootd-plugins
+ccache

--- a/fedora39/packages.txt
+++ b/fedora39/packages.txt
@@ -68,3 +68,4 @@ xrootd-client-devel
 xxhash-devel
 xz-devel
 zlib-devel
+ccache

--- a/fedora40/packages.txt
+++ b/fedora40/packages.txt
@@ -68,3 +68,4 @@ xrootd-client-devel
 xxhash-devel
 xz-devel
 zlib-devel
+ccache

--- a/ubuntu20/packages.txt
+++ b/ubuntu20/packages.txt
@@ -76,3 +76,4 @@ unixodbc-dev
 uuid-dev
 wget
 xlibmesa-glu-dev
+ccache

--- a/ubuntu22/packages.txt
+++ b/ubuntu22/packages.txt
@@ -78,3 +78,4 @@ uuid-dev
 wget
 xlibmesa-glu-dev
 xrootd-plugins
+ccache

--- a/ubuntu2404/packages.txt
+++ b/ubuntu2404/packages.txt
@@ -79,3 +79,4 @@ uuid-dev
 wget
 xlibmesa-glu-dev
 xrootd-plugins
+ccache


### PR DESCRIPTION
This will allow to speed up nightlies and build on push. The cache stays in podman volumes on the build nodes.