### PR TITLE
Rebuild images only on the weekend or when merges happen.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,8 +7,8 @@ on:
     branches:
       - main
   schedule:
-    # every day
-    - cron:  '10 0 * * *'
+    # rebuild every sunday morning
+    - cron:  '15 6 * * 0'
 
 jobs:
   build:


### PR DESCRIPTION
Previously, images were rebuilt every day, which increases the number of stored images in the cern registry to two to three depending on popularity. This prevents us from rebuilding them on the day if desired.

Here, the rebuild is reduced to once per week, letting us start the week with up-to-date images. If we decide to rebuild on a day, there should be enough space to store the second wave of images.