### PR TITLE
Retire Ubuntu20 image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     strategy:
       matrix:
-        distro: [alma8, alma9-clang, debian125, fedora39, fedora40, fedora41, ubuntu20, ubuntu22, ubuntu2404, ubuntu2404-cuda, ubuntu2410]
+        distro: [alma8, alma9-clang, debian125, fedora39, fedora40, fedora41, ubuntu22, ubuntu2404, ubuntu2404-cuda, ubuntu2410]
         platform: [linux/amd64]
         include:
           - distro: alma9


### PR DESCRIPTION
Github will brown-out Ubuntu20 in March, so we would get job failures.

Nightlies for 6.3{0,2,4} should still be able to run from our saved images, but the image won't update, any more.