### PR TITLE
Don't exclude onnx on ubuntu2504

### DIFF
--- a/ubuntu2504/Dockerfile
+++ b/ubuntu2504/Dockerfile
@@ -18,9 +18,7 @@ RUN apt-get update -qq \
 RUN update-ca-certificates
 
 RUN mkdir -p /py-venv \
- && echo "onnx" > forbidden.txt \
- && grep -v -x -F -f forbidden.txt requirements-root.txt > requirements-root-cleaned.txt \
- && python3 -m venv /py-venv/ROOT-CI \
+ && python3 -m venv --system-site-packages /py-venv/ROOT-CI \
  && /py-venv/ROOT-CI/bin/pip install --no-cache-dir --upgrade pip \
- && /py-venv/ROOT-CI/bin/pip install --no-cache-dir -r requirements-root-cleaned.txt -r requirements-roottest.txt openstacksdk \
- && rm -f requirements-root.txt requirements-roottest.txt forbidden.txt requirements-root-cleaned.txt
+ && /py-venv/ROOT-CI/bin/pip install --no-cache-dir -r requirements-root.txt -r requirements-roottest.txt openstacksdk \
+ && rm -f requirements-root.txt requirements-roottest.txt

--- a/ubuntu2504/packages.txt
+++ b/ubuntu2504/packages.txt
@@ -70,6 +70,7 @@ nlohmann-json3-dev
 protobuf-compiler
 python3
 python3-dev
+python3-onnx
 python3-venv
 qtwebengine5-dev
 r-base


### PR DESCRIPTION
By now, Ubuntu has hopefully fixed the situation.