### PR TITLE
Temporarily reduce set of installed Python packages on Fedora 43

### DIFF
--- a/fedora43/Dockerfile
+++ b/fedora43/Dockerfile
@@ -12,5 +12,5 @@ RUN dnf update -y \
 RUN mkdir -p /py-venv \
  && python3 -m venv /py-venv/ROOT-CI \
  && /py-venv/ROOT-CI/bin/pip install --no-cache-dir --upgrade pip \
- && /py-venv/ROOT-CI/bin/pip install --no-cache-dir -r requirements-root.txt openstacksdk \
+ && /py-venv/ROOT-CI/bin/pip install --no-cache-dir numpy pandas pytest setuptools uhi pyspark dask distributed openstacksdk \
  && rm -f requirements-root.txt


### PR DESCRIPTION
Fedora 43 has now upgraded to Python 3.14, but not all packages can be installed yet.

This should be reverted when Python 3.14 is officially released. At that point we will update the `requirements.txt` file in the ROOT repository instead.