### PR TITLE
Add mysql development package to AlmaLinux 10

### DIFF
--- a/alma10/packages.txt
+++ b/alma10/packages.txt
@@ -39,6 +39,7 @@ lz4-devel
 make
 mesa-libGL-devel
 mesa-libGLU-devel
+mysql8.4-devel
 ncurses-libs
 ninja-build
 ocaml-findlib-devel

--- a/fedora43/Dockerfile
+++ b/fedora43/Dockerfile
@@ -12,5 +12,5 @@ RUN dnf update -y \
 RUN mkdir -p /py-venv \
  && python3 -m venv /py-venv/ROOT-CI \
  && /py-venv/ROOT-CI/bin/pip install --no-cache-dir --upgrade pip \
- && /py-venv/ROOT-CI/bin/pip install --no-cache-dir numpy pandas pytest setuptools uhi pyspark dask distributed openstacksdk \
+ && /py-venv/ROOT-CI/bin/pip install --no-cache-dir numpy pandas pytest setuptools uhi pyspark dask distributed openstacksdk cffi \
  && rm -f requirements-root.txt

--- a/fedora43/packages.txt
+++ b/fedora43/packages.txt
@@ -34,6 +34,7 @@ lz4-devel
 make
 mesa-libGL-devel
 mesa-libGLU-devel
+mysql-devel
 ninja-build
 openblas-devel
 openjpeg2-devel


### PR DESCRIPTION
I removed the package before because I thought it was gone, but actually the `mysql-devel` package was just renamed to `mysql8.4-devel`.