### PR TITLE
Don't install jupyter packages on rawhide

### DIFF
--- a/rawhide/Dockerfile
+++ b/rawhide/Dockerfile
@@ -12,5 +12,4 @@ RUN dnf update -y \
 RUN mkdir -p /py-venv \
  && python3-debug -m venv --system-site-packages /py-venv/ROOT-CI \
  && /py-venv/ROOT-CI/bin/pip install --no-cache-dir --upgrade pip \
- && /py-venv/ROOT-CI/bin/pip install --no-cache-dir uhi nbconvert ipython ipykernel metakernel \
  && rm -f requirements-root.txt


### PR DESCRIPTION
This is to disable the jupyter notebook tests, which are currently broken for reasons out of ROOTs control.