### PR TITLE
Update Python version in Alma 8 from Python 3.8 to 3.12

### DIFF
--- a/alma8/Dockerfile
+++ b/alma8/Dockerfile
@@ -10,10 +10,10 @@ RUN dnf update -y \
  && dnf clean all \
  && rm -rf /var/cache/dnf
 
-# We request only Python 3.8 in our packages.txt file but the Alma8 image will
+# We request only Python 3.12 in our packages.txt file but the Alma8 image will
 # present also Python3.6, probably there as a dependency of other packages. Make
 # sure the OS recognizes our Python version as the main one.
-RUN alternatives --set python3 /usr/bin/python3.8
+RUN alternatives --set python3 /usr/bin/python3.12
 
 RUN mkdir -p /py-venv \
  && python3 -m venv /py-venv/ROOT-CI \

--- a/alma8/packages.txt
+++ b/alma8/packages.txt
@@ -51,8 +51,8 @@ postgresql-devel
 protobuf-compiler
 protobuf-devel
 pythia8-devel
-python38
-python38-devel
+python3.12
+python3.12-devel
 qt5-qtwebengine-devel
 R-devel
 R-Rcpp-devel


### PR DESCRIPTION
Python 3.8 was supported in Alma 8 only until May 2023.

The version we should use now is Python 3.12, which has a "Full Life Application Streams Release Life Cycle" inside RHEL 8.

See https://access.redhat.com/support/policy/updates/rhel-app-streams-life-cycle