### PR TITLE
Install  `blas-devel` also on AlmaLinux 8

### DIFF
--- a/alma8/packages.txt
+++ b/alma8/packages.txt
@@ -4,6 +4,7 @@ R-devel
 avahi-compat-libdns_sd-devel
 avahi-devel
 binutils
+blas-devel
 ccache
 cfitsio-devel
 cmake


### PR DESCRIPTION
This will prevent the SOFIE tests from picking up openblas from the system, which will collide with the openblas builtin to NumPy, giving you wrong results or crashes. This was already done for AlmaLinux 9 and 10.