### PR TITLE
rm libafterimage

### DIFF
--- a/alma8/packages.txt
+++ b/alma8/packages.txt
@@ -31,7 +31,6 @@ gtest-devel
 java-17-openjdk
 java-17-openjdk-devel
 json-devel
-libAfterImage-devel
 libX11-devel
 libXext-devel
 libXft-devel

--- a/alma9/packages.txt
+++ b/alma9/packages.txt
@@ -31,7 +31,6 @@ gsl-devel
 gtest-devel
 hdf5-devel
 json-devel
-libAfterImage-devel
 libX11-devel
 libXext-devel
 libXft-devel

--- a/debian125/packages.txt
+++ b/debian125/packages.txt
@@ -14,7 +14,6 @@ gcc
 gfortran
 git
 graphviz-dev
-libafterimage-dev
 libavahi-compat-libdnssd-dev
 libblas-dev
 libcfitsio-dev

--- a/debian13/packages.txt
+++ b/debian13/packages.txt
@@ -14,7 +14,6 @@ gcc
 gfortran
 git
 graphviz-dev
-libafterimage-dev
 libavahi-compat-libdnssd-dev
 libblas-dev
 libcfitsio-dev

--- a/ubuntu22/packages.txt
+++ b/ubuntu22/packages.txt
@@ -13,7 +13,6 @@ gcc
 gfortran
 git
 graphviz-dev
-libafterimage-dev
 libavahi-compat-libdnssd-dev
 libblas-dev
 libcfitsio-dev

--- a/ubuntu2404-cuda/packages.txt
+++ b/ubuntu2404-cuda/packages.txt
@@ -14,7 +14,6 @@ gcc
 gfortran
 git
 graphviz-dev
-libafterimage-dev
 libavahi-compat-libdnssd-dev
 libblas-dev
 libcfitsio-dev

--- a/ubuntu2404/packages.txt
+++ b/ubuntu2404/packages.txt
@@ -15,7 +15,6 @@ gcc
 gfortran
 git
 graphviz-dev
-libafterimage-dev
 libavahi-compat-libdnssd-dev
 libblas-dev
 libcfitsio-dev

--- a/ubuntu2510/packages.txt
+++ b/ubuntu2510/packages.txt
@@ -14,7 +14,6 @@ gcc
 gfortran
 git
 graphviz-dev
-libafterimage-dev
 libblas-dev
 libcfitsio-dev
 libcurl4-openssl-dev

--- a/ubuntu2604/packages.txt
+++ b/ubuntu2604/packages.txt
@@ -14,7 +14,6 @@ gcc
 gfortran
 git
 graphviz-dev
-libafterimage-dev
 libblas-dev
 libcfitsio-dev
 libcrypt-dev


### PR DESCRIPTION
Delete afterimage since system packages are unmaintained.
Add civetweb to avoid using builtin

Fyi @linev @guitargeek 