### PR TITLE
civetweb still uses deprecated API engine

### DIFF
--- a/fedora42/packages.txt
+++ b/fedora42/packages.txt
@@ -43,6 +43,7 @@ ninja-build
 openjpeg2-devel
 openldap-devel
 openssl-devel
+openssl-devel-engine
 pcre2-devel
 postgresql-devel
 protobuf-compiler

--- a/fedora43/packages.txt
+++ b/fedora43/packages.txt
@@ -41,6 +41,7 @@ mysql-devel
 ninja-build
 openjpeg2-devel
 openssl-devel
+openssl-devel-engine
 pcre2-devel
 protobuf-compiler
 protobuf-devel

--- a/fedora44/packages.txt
+++ b/fedora44/packages.txt
@@ -41,6 +41,7 @@ mysql-devel
 ninja-build
 openjpeg2-devel
 openssl-devel
+openssl-devel-engine
 pcre2-devel
 protobuf-compiler
 protobuf-devel

--- a/rawhide/packages.txt
+++ b/rawhide/packages.txt
@@ -39,6 +39,7 @@ mysql-devel
 ninja-build
 openjpeg2-devel
 openssl-devel
+openssl-devel-engine
 pcre2-devel
 protobuf-compiler
 protobuf-devel


### PR DESCRIPTION
needed for https://github.com/root-project/root/pull/21947