### PR TITLE
Add libsm-dev package to Ubuntu and Debian

### DIFF
--- a/debian125/packages.txt
+++ b/debian125/packages.txt
@@ -43,6 +43,7 @@ libpq-dev
 libprotobuf-dev
 libprotoc-dev
 libreadline-dev
+libsm-dev
 libsqlite3-dev
 libssl-dev
 libtbb-dev

--- a/debian13/packages.txt
+++ b/debian13/packages.txt
@@ -42,6 +42,7 @@ libpq-dev
 libprotobuf-dev
 libprotoc-dev
 libreadline-dev
+libsm-dev
 libsqlite3-dev
 libssl-dev
 libtbb-dev

--- a/ubuntu22/packages.txt
+++ b/ubuntu22/packages.txt
@@ -44,6 +44,7 @@ libpq-dev
 libprotobuf-dev
 libprotoc-dev
 libreadline-dev
+libsm-dev
 libsqlite3-dev
 libssl-dev
 libtbb-dev

--- a/ubuntu2404/packages.txt
+++ b/ubuntu2404/packages.txt
@@ -46,6 +46,7 @@ libpq-dev
 libprotobuf-dev
 libprotoc-dev
 libreadline-dev
+libsm-dev
 libsqlite3-dev
 libssl-dev
 libtbb-dev

--- a/ubuntu2510/packages.txt
+++ b/ubuntu2510/packages.txt
@@ -41,6 +41,7 @@ libpq-dev
 libprotobuf-dev
 libprotoc-dev
 libreadline-dev
+libsm-dev
 libsqlite3-dev
 libssl-dev
 libtbb-dev

--- a/ubuntu2604/packages.txt
+++ b/ubuntu2604/packages.txt
@@ -42,6 +42,7 @@ libpq-dev
 libprotobuf-dev
 libprotoc-dev
 libreadline-dev
+libsm-dev
 libsqlite3-dev
 libssl-dev
 libtbb-dev


### PR DESCRIPTION
We require the X11 Session management library (libsm) for our X11 bindings. Before we got it transitively via the libafterimage package, but now that this package is removed, we need to add it explicitly.