### PR TITLE
[ubu26] install system civetweb

### DIFF
--- a/ubuntu2604/packages.txt
+++ b/ubuntu2604/packages.txt
@@ -2,6 +2,7 @@ automake
 binutils
 ca-certificates
 ccache
+civetweb
 cmake
 cppzmq-dev
 curl
@@ -16,6 +17,7 @@ git
 graphviz-dev
 libblas-dev
 libcfitsio-dev
+libcivetweb-dev
 libcrypt-dev
 libcurl4-openssl-dev
 libfftw3-dev


### PR DESCRIPTION
According to my tests on Ubuntu, RBrowser on the web seems to work without issues/crashes when building with builtin_civetweb=OFF

It would be helpful to install these packages so that at least one Ubuntu runs in the CI with system civetweb and we can see how stable that is.

fyi @guitargeek @linev

After this is in, I would open a ROOT PR to turn builtin_civetweb off for ubu26 (default is ON)