### PR TITLE
Add xvfb on opensuse, fedora44 and ubuntu2604

### DIFF
--- a/fedora44/packages.txt
+++ b/fedora44/packages.txt
@@ -34,6 +34,8 @@ libuuid-devel
 libxml2-devel
 libzstd-devel
 lz4-devel
+xorg-x11-server-Xvfb
+xorg-x11-xauth
 make
 mesa-libGL-devel
 mesa-libGLU-devel

--- a/opensuse15/packages.txt
+++ b/opensuse15/packages.txt
@@ -39,6 +39,7 @@ libuuid-devel
 libxml2-devel
 libzstd-devel
 liblz4-devel
+xvfb-run
 make
 Mesa-libGL-devel
 glu-devel

--- a/ubuntu2604/packages.txt
+++ b/ubuntu2604/packages.txt
@@ -63,6 +63,8 @@ libz-dev
 libzmq3-dev
 libzstd-dev
 locales
+xvfb
+xauth
 make
 ninja-build
 nlohmann-json3-dev


### PR DESCRIPTION
They can be used for GUI testing.
PR enabling fitpanel and stressgui will follow