### PR TITLE
Add `zypper dup` for opensuse

### DIFF
--- a/opensuse15/Dockerfile
+++ b/opensuse15/Dockerfile
@@ -6,6 +6,7 @@ COPY packages.txt packages.txt
 ADD https://raw.githubusercontent.com/root-project/root/master/requirements.txt requirements-root.txt
 
 RUN zypper -n ref \
+    && zypper dup -y \
     && zypper -n install --no-recommends $(cat packages.txt) \
     && rm -f packages.txt \
     && zypper -n clean -a \


### PR DESCRIPTION
Update default  `opensuse/leap:15` trying to avoid library conflicts