### PR TITLE
Remove ocaml, krb and ldap

### DIFF
--- a/alma10/packages.txt
+++ b/alma10/packages.txt
@@ -50,7 +50,6 @@ mesa-libGLU-devel
 mysql8.4-devel
 ncurses-libs
 ninja-build
-ocaml-findlib-devel
 openldap-devel
 openssl-devel
 pcre2-devel

--- a/alma8/packages.txt
+++ b/alma8/packages.txt
@@ -48,7 +48,6 @@ mesa-libGLU-devel
 mysql-devel
 ncurses-libs
 ninja-build
-ocaml-findlib-devel
 openldap-devel
 openssl-devel
 pcre2-devel

--- a/alma8/packages.txt
+++ b/alma8/packages.txt
@@ -48,7 +48,6 @@ mesa-libGLU-devel
 mysql-devel
 ncurses-libs
 ninja-build
-openldap-devel
 openssl-devel
 pcre2-devel
 postgresql-devel

--- a/alma9/packages.txt
+++ b/alma9/packages.txt
@@ -49,7 +49,6 @@ mesa-libGLU-devel
 mysql-devel
 ncurses-libs
 ninja-build
-ocaml-findlib-devel
 openldap-devel
 openssl-devel
 pcre2-devel

--- a/alma9/packages.txt
+++ b/alma9/packages.txt
@@ -49,7 +49,6 @@ mesa-libGLU-devel
 mysql-devel
 ncurses-libs
 ninja-build
-openldap-devel
 openssl-devel
 pcre2-devel
 postgresql-devel

--- a/debian125/packages.txt
+++ b/debian125/packages.txt
@@ -34,7 +34,6 @@ libgtest-dev
 libjpeg-dev
 libkrb5-dev
 libldap2-dev
-libllvm-ocaml-dev
 liblz4-dev
 liblzma-dev
 libpcre2-dev

--- a/debian125/packages.txt
+++ b/debian125/packages.txt
@@ -32,8 +32,6 @@ libgsl-dev
 libgsl0-dev
 libgtest-dev
 libjpeg-dev
-libkrb5-dev
-libldap2-dev
 liblz4-dev
 liblzma-dev
 libpcre2-dev

--- a/debian13/packages.txt
+++ b/debian13/packages.txt
@@ -32,8 +32,6 @@ libgsl-dev
 libgsl0-dev
 libgtest-dev
 libjpeg-dev
-libkrb5-dev
-libldap2-dev
 liblz4-dev
 liblzma-dev
 libpcre2-dev

--- a/fedora42/packages.txt
+++ b/fedora42/packages.txt
@@ -41,7 +41,6 @@ mesa-libGLU-devel
 mysql-devel
 ninja-build
 openjpeg2-devel
-openldap-devel
 openssl-devel
 openssl-devel-engine
 pcre2-devel

--- a/opensuse15/packages.txt
+++ b/opensuse15/packages.txt
@@ -46,7 +46,6 @@ glu-devel
 libmariadb-devel
 libncurses6
 ninja
-openldap2-devel
 libopenssl-devel
 pcre2-devel
 postgresql-devel

--- a/opensuse15/packages.txt
+++ b/opensuse15/packages.txt
@@ -46,7 +46,6 @@ glu-devel
 libmariadb-devel
 libncurses6
 ninja
-ocaml-findlib-devel
 openldap2-devel
 libopenssl-devel
 pcre2-devel

--- a/ubuntu22/packages.txt
+++ b/ubuntu22/packages.txt
@@ -34,7 +34,6 @@ libgtest-dev
 libjpeg-dev
 libkrb5-dev
 libldap2-dev
-libllvm-ocaml-dev
 liblz4-dev
 liblzma-dev
 libmysqlclient-dev

--- a/ubuntu22/packages.txt
+++ b/ubuntu22/packages.txt
@@ -32,8 +32,6 @@ libgsl-dev
 libgsl0-dev
 libgtest-dev
 libjpeg-dev
-libkrb5-dev
-libldap2-dev
 liblz4-dev
 liblzma-dev
 libmysqlclient-dev

--- a/ubuntu2404-cuda/packages.txt
+++ b/ubuntu2404-cuda/packages.txt
@@ -34,7 +34,6 @@ libgtest-dev
 libjpeg-dev
 libkrb5-dev
 libldap2-dev
-libllvm-ocaml-dev
 liblz4-dev
 liblzma-dev
 libmysqlclient-dev

--- a/ubuntu2404-cuda/packages.txt
+++ b/ubuntu2404-cuda/packages.txt
@@ -32,8 +32,6 @@ libgsl-dev
 libgsl0-dev
 libgtest-dev
 libjpeg-dev
-libkrb5-dev
-libldap2-dev
 liblz4-dev
 liblzma-dev
 libmysqlclient-dev

--- a/ubuntu2404/packages.txt
+++ b/ubuntu2404/packages.txt
@@ -36,7 +36,6 @@ libgtest-dev
 libjpeg-dev
 libkrb5-dev
 libldap2-dev
-libllvm-ocaml-dev
 liblz4-dev
 liblzma-dev
 libmysqlclient-dev

--- a/ubuntu2404/packages.txt
+++ b/ubuntu2404/packages.txt
@@ -34,8 +34,6 @@ libgsl-dev
 libgsl0-dev
 libgtest-dev
 libjpeg-dev
-libkrb5-dev
-libldap2-dev
 liblz4-dev
 liblzma-dev
 libmysqlclient-dev

--- a/ubuntu2510/packages.txt
+++ b/ubuntu2510/packages.txt
@@ -32,7 +32,6 @@ libgtest-dev
 libjpeg-dev
 libkrb5-dev
 libldap2-dev
-libllvm-ocaml-dev
 liblz4-dev
 liblzma-dev
 libpcre2-dev

--- a/ubuntu2510/packages.txt
+++ b/ubuntu2510/packages.txt
@@ -30,8 +30,6 @@ libgsl-dev
 libgsl0-dev
 libgtest-dev
 libjpeg-dev
-libkrb5-dev
-libldap2-dev
 liblz4-dev
 liblzma-dev
 libpcre2-dev

--- a/ubuntu2604/packages.txt
+++ b/ubuntu2604/packages.txt
@@ -35,7 +35,6 @@ libgtest-dev
 libjpeg-dev
 libkrb5-dev
 libldap2-dev
-libllvm-ocaml-dev
 liblz4-dev
 liblzma-dev
 libpcre2-dev

--- a/ubuntu2604/packages.txt
+++ b/ubuntu2604/packages.txt
@@ -33,8 +33,6 @@ libgsl-dev
 libgsl0-dev
 libgtest-dev
 libjpeg-dev
-libkrb5-dev
-libldap2-dev
 liblz4-dev
 liblzma-dev
 libpcre2-dev


### PR DESCRIPTION
For ocaml, it's not needed anywhere in ROOT and llvm.
For the other three, they are not needed since ROOT 6.18 (see https://root.cern/doc/v618/release-notes.html)