### PR TITLE
opensuse15 - use libpng16-devel

### DIFF
--- a/opensuse15/packages.txt
+++ b/opensuse15/packages.txt
@@ -27,7 +27,7 @@ gtest
 gzip
 hdf5-devel
 libjson-c-devel
-libpng-devel
+libpng16-devel
 libX11-devel
 libXext-devel
 libXft-devel


### PR DESCRIPTION
It is correct name for libpng