### PR TITLE
Install free-threaded Python package on Fedora Rawhide

### DIFF
--- a/rawhide/Dockerfile
+++ b/rawhide/Dockerfile
@@ -9,8 +9,14 @@ RUN dnf update -y \
  && dnf clean all \
  && rm -rf /var/cache/dnf
 
+RUN mkdir -p /py-venv-3.14t \
+ && python3.14t -m venv /py-venv-3.14t/ROOT-CI \
+ && /py-venv-3.14t/ROOT-CI/bin/pip install --no-cache-dir --upgrade pip \
+ && /py-venv-3.14t/ROOT-CI/bin/pip install --no-cache-dir numpy pytest setuptools
+
 RUN mkdir -p /py-venv \
  && python3-debug -m venv --system-site-packages /py-venv/ROOT-CI \
  && /py-venv/ROOT-CI/bin/pip install --no-cache-dir --upgrade pip \
- && /py-venv/ROOT-CI/bin/pip install --no-cache-dir uhi nbconvert ipython ipykernel metakernel \
- && rm -f requirements-root.txt
+ && /py-venv/ROOT-CI/bin/pip install --no-cache-dir uhi nbconvert ipython ipykernel metakernel
+
+RUN rm -f requirements-root.txt

--- a/rawhide/packages.txt
+++ b/rawhide/packages.txt
@@ -53,6 +53,7 @@ python3-openstacksdk
 python3-pandas
 python3-pytest
 python3-setuptools
+python3.14-freethreading
 readline-devel
 sqlite-devel
 tbb-devel


### PR DESCRIPTION
This will allow us one day to test ROOT with free-threaded Python (no GIL) in the CI.