### PR TITLE
packages needed for building with builtin_llvm=OFF

### DIFF
--- a/ubuntu2604/packages.txt
+++ b/ubuntu2604/packages.txt
@@ -20,6 +20,7 @@ libcfitsio-dev
 libcivetweb-dev
 libcrypt-dev
 libcurl4-openssl-dev
+libedit-dev
 libfftw3-dev
 libfreetype6-dev
 libftgl-dev
@@ -62,6 +63,7 @@ libxxhash-dev
 libz-dev
 libzmq3-dev
 libzstd-dev
+llvm-20
 locales
 xvfb
 xauth

--- a/ubuntu2604/packages.txt
+++ b/ubuntu2604/packages.txt
@@ -41,6 +41,7 @@ liblz4-dev
 liblzma-dev
 libpcre2-dev
 libpng-dev
+libpolly-20-dev
 libpq-dev
 libprotobuf-dev
 libprotoc-dev

--- a/ubuntu2604/packages.txt
+++ b/ubuntu2604/packages.txt
@@ -42,6 +42,7 @@ liblzma-dev
 libpcre2-dev
 libpng-dev
 libpolly-20-dev
+libpolly-22-dev
 libpq-dev
 libprotobuf-dev
 libprotoc-dev
@@ -65,6 +66,7 @@ libz-dev
 libzmq3-dev
 libzstd-dev
 llvm-20
+llvm-22
 locales
 xvfb
 xauth


### PR DESCRIPTION
In the CI there is not a single platform where this option is tested, so I propose doing that with Ubu26 CI

This is a small step towards https://github.com/root-project/root/issues/19265

fyi @dpiparo @guitargeek