### PR TITLE
Add CEF to opensuse16 and fedora44

### DIFF
--- a/fedora44/Dockerfile
+++ b/fedora44/Dockerfile
@@ -9,6 +9,23 @@ RUN dnf update -y \
  && dnf clean all \
  && rm -rf /var/cache/dnf
 
+ # install CEF
+RUN mkdir -p /opt/cef \
+    && cd /opt/cef \
+    && curl -L https://cef-builds.spotifycdn.com/cef_binary_148.0.10%2Bg7ee53f5%2Bchromium-148.0.7778.218_linux64_minimal.tar.bz2 -o cef.tar.bz2 \
+    && curl -L https://cef-builds.spotifycdn.com/cef_binary_148.0.10%2Bg7ee53f5%2Bchromium-148.0.7778.218_linux64_minimal.tar.bz2.sha1 -o cef.tar.bz2.sha1 \
+    && [ "$(cat cef.tar.bz2.sha1)" = "$(sha1sum cef.tar.bz2 | awk '{print $1}')" ] \
+    && tar xjf cef.tar.bz2 \
+    && mv 'cef_binary_148.0.10+g7ee53f5+chromium-148.0.7778.218_linux64_minimal' cef_binary_148 \
+    && cd cef_binary_148 \
+    && mkdir build \
+    && cd build \
+    && cmake .. \
+    && cmake --build . --target libcef_dll_wrapper -j4
+
+# set shell variable for ROOT build
+ENV CEF_ROOT=/opt/cef/cef_binary_148
+
 # Install torch directly from pytorch.org to avoid pulling in CUDA
 RUN mkdir -p /py-venv \
  && python3 -m venv /py-venv/ROOT-CI \

--- a/opensuse16/Dockerfile
+++ b/opensuse16/Dockerfile
@@ -14,6 +14,23 @@ RUN zypper --gpg-auto-import-keys -n ref \
     && zypper -n clean -a \
     && rm -rf /var/cache/zypp
 
+# install CEF
+RUN mkdir -p /opt/cef \
+    && cd /opt/cef \
+    && curl -L https://cef-builds.spotifycdn.com/cef_binary_148.0.10%2Bg7ee53f5%2Bchromium-148.0.7778.218_linux64_minimal.tar.bz2 -o cef.tar.bz2 \
+    && curl -L https://cef-builds.spotifycdn.com/cef_binary_148.0.10%2Bg7ee53f5%2Bchromium-148.0.7778.218_linux64_minimal.tar.bz2.sha1 -o cef.tar.bz2.sha1 \
+    && [ "$(cat cef.tar.bz2.sha1)" = "$(sha1sum cef.tar.bz2 | awk '{print $1}')" ] \
+    && tar xjf cef.tar.bz2 \
+    && mv 'cef_binary_148.0.10+g7ee53f5+chromium-148.0.7778.218_linux64_minimal' cef_binary_148 \
+    && cd cef_binary_148 \
+    && mkdir build \
+    && cd build \
+    && cmake .. \
+    && cmake --build . --target libcef_dll_wrapper -j4
+
+# set shell variable for ROOT build
+ENV CEF_ROOT=/opt/cef/cef_binary_148
+
 # Install torch directly from pytorch.org to avoid pulling in CUDA
 RUN mkdir -p /py-venv \
     && python3 -m venv /py-venv/ROOT-CI \


### PR DESCRIPTION
Latest CEF builds provide view frameworks by default.
This allows to use CEF in headless mode - ROOT batch graphics production.
Plus normal interactive browser window - which does not require HTTP.

So adding CEF to CI images will allow me to enable testing of `stressGraphics` with CEF.

On my test machine "headless" CEF also works on Windows and partially (without WebGL) on Mac.
There is good chance that after some debugging CEF can provide full webgui support. 

