### PR TITLE
Remove deprecated OpenSSL engine package from Rawhide

### DIFF
--- a/rawhide/packages.txt
+++ b/rawhide/packages.txt
@@ -39,7 +39,6 @@ mysql-devel
 ninja-build
 openjpeg2-devel
 openssl-devel
-openssl-devel-engine
 pcre2-devel
 protobuf-compiler
 protobuf-devel


### PR DESCRIPTION
The package was dropped upstream, and is not used by ROOT anyway.