### PR TITLE
Test cooldown option for pip.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,11 @@ name: Create images
 on:
   pull_request:
   workflow_dispatch:
+    inputs:
+      ignore_pip_cooldown:
+        description: 'Ignore the cooldown period for pip installs'
+        default: false
+        type: boolean
   push:
     branches:
       - main
@@ -84,3 +89,4 @@ jobs:
           no-cache: ${{ github.event_name != 'push' && github.event_name != 'pull_request' }}
           cache-from: type=gha,scope=${{ matrix.distro }}
           cache-to: type=gha,mode=max,scope=${{ matrix.distro }}
+          build-args: ${{ inputs.ignore_pip_cooldown && 'PIP_COOLDOWN=' || '' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,7 +84,7 @@ jobs:
           platforms: ${{ matrix.platform }}
           context: ./${{ matrix.distro }}/
           push: ${{ github.event_name != 'pull_request' }}
-          tags: registry.cern.ch/root-ci/${{ matrix.distro }}${{ matrix.arch}}:buildready
+          tags: registry.cern.ch/root-ci/${{ matrix.distro }}:buildready
           labels: org.opencontainers.image.source=https://github.com/${{ github.repository }}
           no-cache: ${{ github.event_name != 'push' && github.event_name != 'pull_request' }}
           cache-from: type=gha,scope=${{ matrix.distro }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,10 @@ on:
     # every day
     - cron:  '10 0 * * *'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     strategy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,7 +70,7 @@ jobs:
           password: ${{ secrets.CR_PAT }}
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           platforms: ${{ matrix.platform }}
           context: ./${{ matrix.distro }}/

--- a/alma10/Dockerfile
+++ b/alma10/Dockerfile
@@ -1,5 +1,7 @@
 FROM almalinux:10
 
+ARG PIP_COOLDOWN=--uploaded-prior-to=P7D
+
 COPY packages.txt packages.txt
 ADD https://raw.githubusercontent.com/root-project/root/master/requirements.txt requirements-root.txt
 
@@ -17,5 +19,5 @@ RUN mkdir -p /py-venv \
  && python3 -m venv /py-venv/ROOT-CI \
  && /py-venv/ROOT-CI/bin/pip install --no-cache-dir --upgrade pip \
  && /py-venv/ROOT-CI/bin/pip install --no-cache-dir --index-url https://download.pytorch.org/whl/cpu torch \
- && /py-venv/ROOT-CI/bin/pip install --no-cache-dir -r requirements-root.txt openstacksdk \
+ && /py-venv/ROOT-CI/bin/pip install ${PIP_COOLDOWN} --no-cache-dir -r requirements-root.txt openstacksdk \
  && rm -f requirements-root.txt

--- a/alma8/Dockerfile
+++ b/alma8/Dockerfile
@@ -1,5 +1,7 @@
 FROM gitlab-registry.cern.ch/linuxsupport/alma8-base
 
+ARG PIP_COOLDOWN=--uploaded-prior-to=P7D
+
 COPY packages.txt packages.txt
 ADD https://raw.githubusercontent.com/root-project/root/master/requirements.txt requirements-root.txt
 
@@ -25,5 +27,5 @@ RUN mkdir -p /py-venv \
  && python3 -m venv /py-venv/ROOT-CI \
  && /py-venv/ROOT-CI/bin/pip install --no-cache-dir --upgrade pip \
  && /py-venv/ROOT-CI/bin/pip install --no-cache-dir --index-url https://download.pytorch.org/whl/cpu torch \
- && /py-venv/ROOT-CI/bin/pip install --no-cache-dir -r requirements-root.txt openstacksdk \
+ && /py-venv/ROOT-CI/bin/pip install ${PIP_COOLDOWN} --no-cache-dir -r requirements-root.txt openstacksdk \
  && rm -f requirements-root.txt

--- a/alma9/Dockerfile
+++ b/alma9/Dockerfile
@@ -1,5 +1,7 @@
 FROM gitlab-registry.cern.ch/linuxsupport/alma9-base
 
+ARG PIP_COOLDOWN=--uploaded-prior-to=P7D
+
 COPY packages.txt packages.txt
 ADD https://raw.githubusercontent.com/root-project/root/master/requirements.txt requirements-root.txt
 
@@ -20,5 +22,5 @@ RUN mkdir -p /py-venv \
  && python3 -m venv /py-venv/ROOT-CI \
  && /py-venv/ROOT-CI/bin/pip install --no-cache-dir --upgrade pip \
  && /py-venv/ROOT-CI/bin/pip install --no-cache-dir --index-url https://download.pytorch.org/whl/cpu torch \
- && /py-venv/ROOT-CI/bin/pip install --no-cache-dir -r requirements-root.txt openstacksdk \
+ && /py-venv/ROOT-CI/bin/pip install ${PIP_COOLDOWN} --no-cache-dir -r requirements-root.txt openstacksdk \
  && rm -f requirements-root.txt

--- a/debian125/Dockerfile
+++ b/debian125/Dockerfile
@@ -1,5 +1,7 @@
 FROM debian:12.5
 
+ARG PIP_COOLDOWN=--uploaded-prior-to=P7D
+
 ENV LANG=C.UTF-8
 
 COPY packages.txt packages.txt
@@ -21,5 +23,5 @@ RUN mkdir -p /py-venv \
  && python3 -m venv /py-venv/ROOT-CI \
  && /py-venv/ROOT-CI/bin/pip install --no-cache-dir --upgrade pip \
  && /py-venv/ROOT-CI/bin/pip install --no-cache-dir --index-url https://download.pytorch.org/whl/cpu torch \
- && /py-venv/ROOT-CI/bin/pip install --no-cache-dir -r requirements-root.txt openstacksdk \
+ && /py-venv/ROOT-CI/bin/pip install ${PIP_COOLDOWN} --no-cache-dir -r requirements-root.txt openstacksdk \
  && rm -f requirements-root.txt

--- a/debian13/Dockerfile
+++ b/debian13/Dockerfile
@@ -1,5 +1,7 @@
 FROM debian:trixie
 
+ARG PIP_COOLDOWN=--uploaded-prior-to=P7D
+
 ENV LANG=C.UTF-8
 
 COPY packages.txt packages.txt
@@ -28,7 +30,7 @@ RUN if [ "$TARGETARCH" != "386" ]; then \
         && python3 -m venv /py-venv/ROOT-CI \
         && /py-venv/ROOT-CI/bin/pip install --no-cache-dir --upgrade pip \
         && /py-venv/ROOT-CI/bin/pip install --no-cache-dir --index-url https://download.pytorch.org/whl/cpu torch \
-        && /py-venv/ROOT-CI/bin/pip install --no-cache-dir -r requirements-root.txt openstacksdk \
+        && /py-venv/ROOT-CI/bin/pip install ${PIP_COOLDOWN} --no-cache-dir -r requirements-root.txt openstacksdk \
         && rm -f requirements-root.txt;\
     fi
 

--- a/fedora43/Dockerfile
+++ b/fedora43/Dockerfile
@@ -1,5 +1,7 @@
 FROM fedora:43
 
+ARG PIP_COOLDOWN=--uploaded-prior-to=P7D
+
 COPY packages.txt packages.txt
 ADD https://raw.githubusercontent.com/root-project/root/master/requirements.txt requirements-root.txt
 
@@ -14,5 +16,5 @@ RUN mkdir -p /py-venv \
  && python3 -m venv /py-venv/ROOT-CI \
  && /py-venv/ROOT-CI/bin/pip install --no-cache-dir --upgrade pip \
  && /py-venv/ROOT-CI/bin/pip install --no-cache-dir --index-url https://download.pytorch.org/whl/cpu torch \
- && /py-venv/ROOT-CI/bin/pip install --no-cache-dir -r requirements-root.txt openstacksdk \
+ && /py-venv/ROOT-CI/bin/pip install ${PIP_COOLDOWN} --no-cache-dir -r requirements-root.txt openstacksdk \
  && rm -f requirements-root.txt

--- a/fedora44/Dockerfile
+++ b/fedora44/Dockerfile
@@ -1,5 +1,7 @@
 FROM fedora:44
 
+ARG PIP_COOLDOWN=--uploaded-prior-to=P7D
+
 COPY packages.txt packages.txt
 ADD https://raw.githubusercontent.com/root-project/root/master/requirements.txt requirements-root.txt
 
@@ -32,5 +34,5 @@ RUN mkdir -p /py-venv \
  && python3 -m venv /py-venv/ROOT-CI \
  && /py-venv/ROOT-CI/bin/pip install --no-cache-dir --upgrade pip \
  && /py-venv/ROOT-CI/bin/pip install --no-cache-dir --index-url https://download.pytorch.org/whl/cpu torch \
- && /py-venv/ROOT-CI/bin/pip install --no-cache-dir -r requirements-root.txt openstacksdk \
+ && /py-venv/ROOT-CI/bin/pip install ${PIP_COOLDOWN} --no-cache-dir -r requirements-root.txt openstacksdk \
  && rm -f requirements-root.txt

--- a/fedora45/Dockerfile
+++ b/fedora45/Dockerfile
@@ -1,5 +1,7 @@
 FROM fedora:45
 
+ARG PIP_COOLDOWN=--uploaded-prior-to=P7D
+
 COPY packages.txt packages.txt
 ADD https://raw.githubusercontent.com/root-project/root/master/requirements.txt requirements-root.txt
 
@@ -45,5 +47,5 @@ RUN mkdir -p /py-venv \
  && python3 -m venv /py-venv/ROOT-CI \
  && /py-venv/ROOT-CI/bin/pip install --no-cache-dir --upgrade pip \
  && /py-venv/ROOT-CI/bin/pip install --no-cache-dir --index-url https://download.pytorch.org/whl/cpu torch \
- && /py-venv/ROOT-CI/bin/pip install --no-cache-dir -r requirements-root-cleaned.txt openstacksdk \
+ && /py-venv/ROOT-CI/bin/pip install ${PIP_COOLDOWN} --no-cache-dir -r requirements-root-cleaned.txt openstacksdk \
  && rm -f requirements-root.txt forbidden.txt requirements-root-cleaned.txt

--- a/opensuse16/Dockerfile
+++ b/opensuse16/Dockerfile
@@ -1,5 +1,7 @@
 FROM opensuse/leap:16.0
 
+ARG PIP_COOLDOWN=--uploaded-prior-to=P7D
+
 ENV LANG=C.UTF-8
 
 COPY packages.txt packages.txt
@@ -37,5 +39,5 @@ RUN mkdir -p /py-venv \
     && python3 -m venv /py-venv/ROOT-CI \
     && /py-venv/ROOT-CI/bin/pip install --no-cache-dir --upgrade pip \
     && /py-venv/ROOT-CI/bin/pip install --no-cache-dir --index-url https://download.pytorch.org/whl/cpu torch \
-    && /py-venv/ROOT-CI/bin/pip install --no-cache-dir -r requirements-root.txt openstacksdk \
+    && /py-venv/ROOT-CI/bin/pip install ${PIP_COOLDOWN} --no-cache-dir -r requirements-root.txt openstacksdk \
     && rm -f requirements-root.txt

--- a/rawhide/Dockerfile
+++ b/rawhide/Dockerfile
@@ -1,5 +1,7 @@
 FROM fedora:rawhide
 
+ARG PIP_COOLDOWN=--uploaded-prior-to=P7D
+
 COPY packages.txt packages.txt
 
 RUN dnf update -y \

--- a/ubuntu22/Dockerfile
+++ b/ubuntu22/Dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:22.04
 
+ARG PIP_COOLDOWN=--uploaded-prior-to=P7D
+
 ENV LANG=C.UTF-8
 
 COPY packages.txt packages.txt
@@ -28,5 +30,5 @@ RUN mkdir -p /py-venv \
  && python3 -m venv /py-venv/ROOT-CI \
  && /py-venv/ROOT-CI/bin/pip install --no-cache-dir --upgrade pip \
  && /py-venv/ROOT-CI/bin/pip install --no-cache-dir --index-url https://download.pytorch.org/whl/cpu torch \
- && /py-venv/ROOT-CI/bin/pip install --no-cache-dir -r requirements-root.txt openstacksdk \
+ && /py-venv/ROOT-CI/bin/pip install ${PIP_COOLDOWN} --no-cache-dir -r requirements-root.txt openstacksdk \
  && rm -f requirements-root.txt

--- a/ubuntu2404-cuda/Dockerfile
+++ b/ubuntu2404-cuda/Dockerfile
@@ -1,4 +1,7 @@
 FROM nvidia/cuda:13.2.0-cudnn-devel-ubuntu24.04
+
+ARG PIP_COOLDOWN=--uploaded-prior-to=P7D
+
 ENV LANG=C.UTF-8
 
 COPY packages.txt packages.txt
@@ -20,5 +23,5 @@ RUN mkdir -p /py-venv \
  && python3 -m venv /py-venv/ROOT-CI \
  && /py-venv/ROOT-CI/bin/pip install --no-cache-dir --upgrade pip \
  && /py-venv/ROOT-CI/bin/pip install --no-cache-dir --index-url https://download.pytorch.org/whl/cpu torch \
- && /py-venv/ROOT-CI/bin/pip install --no-cache-dir -r requirements-root.txt openstacksdk \
+ && /py-venv/ROOT-CI/bin/pip install ${PIP_COOLDOWN} --no-cache-dir -r requirements-root.txt openstacksdk \
  && rm -f requirements-root.txt

--- a/ubuntu2404/Dockerfile
+++ b/ubuntu2404/Dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:24.04
 
+ARG PIP_COOLDOWN=--uploaded-prior-to=P7D
+
 ENV LANG=C.UTF-8
 
 COPY packages.txt packages.txt
@@ -21,5 +23,5 @@ RUN mkdir -p /py-venv \
  && python3 -m venv /py-venv/ROOT-CI \
  && /py-venv/ROOT-CI/bin/pip install --no-cache-dir --upgrade pip \
  && /py-venv/ROOT-CI/bin/pip install --no-cache-dir --index-url https://download.pytorch.org/whl/cpu torch \
- && /py-venv/ROOT-CI/bin/pip install --no-cache-dir -r requirements-root.txt openstacksdk \
+ && /py-venv/ROOT-CI/bin/pip install ${PIP_COOLDOWN} --no-cache-dir -r requirements-root.txt openstacksdk \
  && rm -f requirements-root.txt

--- a/ubuntu2604/Dockerfile
+++ b/ubuntu2604/Dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:26.04
 
+ARG PIP_COOLDOWN=--uploaded-prior-to=P7D
+
 ENV LANG=C.UTF-8
 
 COPY packages.txt packages.txt
@@ -21,5 +23,5 @@ RUN mkdir -p /py-venv \
  && python3 -m venv /py-venv/ROOT-CI \
  && /py-venv/ROOT-CI/bin/pip install --no-cache-dir --upgrade pip \
  && /py-venv/ROOT-CI/bin/pip install --no-cache-dir --index-url https://download.pytorch.org/whl/cpu torch \
- && /py-venv/ROOT-CI/bin/pip install --no-cache-dir -r requirements-root.txt openstacksdk \
+ && /py-venv/ROOT-CI/bin/pip install ${PIP_COOLDOWN} --no-cache-dir -r requirements-root.txt openstacksdk \
  && rm -f requirements-root.txt

--- a/ubuntu2610/Dockerfile
+++ b/ubuntu2610/Dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:26.10
 
+ARG PIP_COOLDOWN=--uploaded-prior-to=P7D
+
 ENV LANG=C.UTF-8
 
 COPY packages.txt packages.txt
@@ -21,5 +23,5 @@ RUN mkdir -p /py-venv \
  && python3 -m venv /py-venv/ROOT-CI \
  && /py-venv/ROOT-CI/bin/pip install --no-cache-dir --upgrade pip \
  && /py-venv/ROOT-CI/bin/pip install --no-cache-dir --index-url https://download.pytorch.org/whl/cpu torch \
- && /py-venv/ROOT-CI/bin/pip install --no-cache-dir -r requirements-root.txt openstacksdk \
+ && /py-venv/ROOT-CI/bin/pip install ${PIP_COOLDOWN} --no-cache-dir -r requirements-root.txt openstacksdk \
  && rm -f requirements-root.txt


### PR DESCRIPTION
- Add a docker-level variable to set a cooldown option for pip
  - In the future, we could pass custom values to it from the build command, but it currently defaults to seven days.
- Update the build action to v7.
- Also limit the concurrency of the jobs to ensure that the previous iteration is cancelled when a new run is triggered.